### PR TITLE
API Authentication Update 3.0.5

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Zabbix Dashboard",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Zabbix dashboard",
   "author": "火星小刘",
   "homepage_url": "https://github.com/X-Mars/zabbix_browser_addons",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zabbix_addons_new",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "",
   "main": "generate_icons.js",
   "scripts": {


### PR DESCRIPTION
Following Zabbix official documentation recommendations, changed API authentication from `auth` property in request body to `Authorization: Bearer <token>` header authentication